### PR TITLE
Add initial mnl abstraction code

### DIFF
--- a/mnl-sys/Cargo.toml
+++ b/mnl-sys/Cargo.toml
@@ -16,7 +16,7 @@ default = ["mnl-1-0-4"]
 mnl-1-0-4 = []
 
 [dependencies]
-libc = { version = "0.2", git = "https://github.com/faern/libc" }
+libc = "0.2.37"
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/mnl/Cargo.toml
+++ b/mnl/Cargo.toml
@@ -17,6 +17,5 @@ default = ["mnl-sys/default"]
 mnl-1-0-4 = ["mnl-sys/mnl-1-0-4"]
 
 [dependencies]
-libc = { version = "0.2", git = "https://github.com/faern/libc" }
 log = "0.4"
 mnl-sys = { path = "../mnl-sys", version = "0.1", default-features = false }

--- a/mnl/src/callback.rs
+++ b/mnl/src/callback.rs
@@ -1,0 +1,27 @@
+use mnl_sys;
+use mnl_sys::libc::c_void;
+
+use std::io;
+use std::ptr;
+
+
+/// The result of processing a batch of netlink responses.
+pub enum CbResult {
+    /// Everything went fine and this batch is finished processing.
+    Stop,
+    /// Everything went fine, but we expect more messages to come back from the kernel for this
+    /// batch.
+    Ok,
+}
+
+/// Callback runqueue for netlink messages. Checks that all netlink messages in `buffer` are OK.
+pub fn cb_run(buffer: &[u8], seq: u32, portid: u32) -> io::Result<CbResult> {
+    let len = buffer.len();
+    let buf = buffer.as_ptr() as *const c_void;
+    debug!("Processing {} byte netlink message", len);
+    match unsafe { mnl_sys::mnl_cb_run(buf, len, seq, portid, None, ptr::null_mut()) } {
+        i if i <= -1 => Err(io::Error::last_os_error()),
+        mnl_sys::MNL_CB_STOP => Ok(CbResult::Stop),
+        _ => Ok(CbResult::Ok),
+    }
+}

--- a/mnl/src/cvt.rs
+++ b/mnl/src/cvt.rs
@@ -1,0 +1,46 @@
+use std::io;
+
+
+pub trait IsMinusOne {
+    fn is_minus_one(&self) -> bool;
+}
+
+macro_rules! impl_is_minus_one {
+    ($($t:ident)*) => ($(impl IsMinusOne for $t {
+        fn is_minus_one(&self) -> bool {
+            *self == -1
+        }
+    })*)
+}
+
+impl_is_minus_one! { i8 i16 i32 i64 isize }
+
+pub trait IsError {
+    fn is_error(&self) -> bool;
+}
+
+impl<T: IsMinusOne> IsError for T {
+    fn is_error(&self) -> bool {
+        self.is_minus_one()
+    }
+}
+
+impl<T> IsError for *const T {
+    fn is_error(&self) -> bool {
+        (*self as *const T).is_null()
+    }
+}
+
+impl<T> IsError for *mut T {
+    fn is_error(&self) -> bool {
+        (*self as *mut T).is_null()
+    }
+}
+
+pub fn cvt<T: IsError>(t: T) -> io::Result<T> {
+    if t.is_error() {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(t)
+    }
+}

--- a/mnl/src/lib.rs
+++ b/mnl/src/lib.rs
@@ -6,6 +6,44 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![cfg(target_os = "linux")]
+//! Safe abstraction for [`libmnl`]. A minimalistic user-space library oriented to Netlink
+//! developers. See [`mnl-sys`] for the low level FFI bindings to the C library.
+//!
+//! This is work in progress and does not implement all of [`libmnl`] yet. Feel free to submit PRs
+//! to support the parts you need!
+//!
+//! The initial focus here was to support sockets and the parsing of responses. So so far the best
+//! covered parts are `mnl_socket_*` and `mnl_cb_run`. However the netlink messages are just
+//! treated as raw byte buffers. It might make sense to add some abstraction struct at some point.
+//!
+//! # Prior/related work
+//!
+//! The [`crslmnl`] crate is another wrapper around [`libmnl`]. At this stage it is a far more
+//! complete abstraction of the library than this is. There are a few reasons I decided to start a
+//! new wrapper crate. I'm not going to go into details on why, but basically it did not support
+//! part of my use-case and I was no fan of the design choices made. Instead of having local
+//! definitions of all the Linux header constants I made sure to get everything needed for netlink
+//! [merged into `libc`]. I also want a separate [`mnl-sys`] crate that is pure FFI bindings
+//! without logic or abstractions.
+//!
+//! [`libmnl`]: https://netfilter.org/projects/libmnl/
+//! [`mnl-sys`]: https://crates.io/crates/mnl-sys
+//! [`crslmnl`]: https://crates.io/crates/crslmnl
+//! [merged into `libc`]: https://github.com/rust-lang/libc/pull/922
 
+#![cfg(target_os = "linux")]
+#![deny(missing_docs)]
+
+#[macro_use]
+extern crate log;
 pub extern crate mnl_sys;
+
+/// Module for helper functions checking FFI return values for error codes.
+/// "cvt" stands for "check value T", where T is the return value
+mod cvt;
+
+mod callback;
+pub use callback::*;
+
+mod socket;
+pub use socket::*;

--- a/mnl/src/socket.rs
+++ b/mnl/src/socket.rs
@@ -1,0 +1,176 @@
+use mnl_sys;
+use mnl_sys::libc::{self, c_uint, c_void};
+
+use std::io;
+use std::mem;
+use std::os::unix::io::{AsRawFd, RawFd};
+
+use cvt::cvt;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+#[allow(missing_docs)]
+#[repr(i32)]
+pub enum Bus {
+    Route = libc::NETLINK_ROUTE,
+    Unused = libc::NETLINK_UNUSED,
+    Usersock = libc::NETLINK_USERSOCK,
+    Firewall = libc::NETLINK_FIREWALL,
+    SockDiag = libc::NETLINK_SOCK_DIAG,
+    Nflog = libc::NETLINK_NFLOG,
+    Xfrm = libc::NETLINK_XFRM,
+    Selinux = libc::NETLINK_SELINUX,
+    Iscsi = libc::NETLINK_ISCSI,
+    Audit = libc::NETLINK_AUDIT,
+    FibLookup = libc::NETLINK_FIB_LOOKUP,
+    Connector = libc::NETLINK_CONNECTOR,
+    Netfilter = libc::NETLINK_NETFILTER,
+    Ip6Fw = libc::NETLINK_IP6_FW,
+    Dnrtmsg = libc::NETLINK_DNRTMSG,
+    KobjectUevent = libc::NETLINK_KOBJECT_UEVENT,
+    Generic = libc::NETLINK_GENERIC,
+    Scsitransport = libc::NETLINK_SCSITRANSPORT,
+    Ecryptfs = libc::NETLINK_ECRYPTFS,
+    Rdma = libc::NETLINK_RDMA,
+    Crypto = libc::NETLINK_CRYPTO,
+}
+
+impl Bus {
+    /// Converts the given integer to a netlink bus variant. Returns `None` if the value does
+    /// not match any bus.
+    pub fn try_from(bus: i32) -> Option<Self> {
+        use Bus::*;
+        let variant = match bus {
+            libc::NETLINK_ROUTE => Route,
+            libc::NETLINK_UNUSED => Unused,
+            libc::NETLINK_USERSOCK => Usersock,
+            libc::NETLINK_FIREWALL => Firewall,
+            libc::NETLINK_SOCK_DIAG => SockDiag,
+            libc::NETLINK_NFLOG => Nflog,
+            libc::NETLINK_XFRM => Xfrm,
+            libc::NETLINK_SELINUX => Selinux,
+            libc::NETLINK_ISCSI => Iscsi,
+            libc::NETLINK_AUDIT => Audit,
+            libc::NETLINK_FIB_LOOKUP => FibLookup,
+            libc::NETLINK_CONNECTOR => Connector,
+            libc::NETLINK_NETFILTER => Netfilter,
+            libc::NETLINK_IP6_FW => Ip6Fw,
+            libc::NETLINK_DNRTMSG => Dnrtmsg,
+            libc::NETLINK_KOBJECT_UEVENT => KobjectUevent,
+            libc::NETLINK_GENERIC => Generic,
+            libc::NETLINK_SCSITRANSPORT => Scsitransport,
+            libc::NETLINK_ECRYPTFS => Ecryptfs,
+            libc::NETLINK_RDMA => Rdma,
+            libc::NETLINK_CRYPTO => Crypto,
+            _ => return None,
+        };
+        Some(variant)
+    }
+}
+
+
+/// A netlink socket. Wraps the underlying `libmnl` `mnl_socket` struct and provides a safe Rust
+/// API.
+///
+/// Dropping an open socket will automatically try to close it. But any error during closing will
+/// simply be discarded. So use the [`close`] method to catch and handle any close error.
+///
+/// [`close`]: #method.close
+pub struct Socket {
+    socket: *mut mnl_sys::mnl_socket,
+}
+
+impl Socket {
+    /// Opens a new Netlink socket to the given bus ID, and binds it to group zero and with an
+    /// automatic port id (MNL_SOCKET_AUTOPID).
+    ///
+    /// Use [`open`] and [`bind`] for more fine grained control.
+    ///
+    /// [`open`]: #method.open
+    /// [`bind`]: #method.bind
+    pub fn new(bus: Bus) -> io::Result<Self> {
+        let socket = Self::open(bus)?;
+        socket.bind(0, mnl_sys::MNL_SOCKET_AUTOPID)?;
+        Ok(socket)
+    }
+
+    /// Opens a new Netlink socket to the given bus ID.
+    pub fn open(bus: Bus) -> io::Result<Self> {
+        Ok(Socket {
+            socket: cvt(unsafe { mnl_sys::mnl_socket_open(bus as i32) })?,
+        })
+    }
+
+    /// Bind the Netlink socket.
+    pub fn bind(&self, groups: c_uint, pid: libc::pid_t) -> io::Result<()> {
+        cvt(unsafe { mnl_sys::mnl_socket_bind(self.socket, groups, pid) })?;
+        Ok(())
+    }
+
+    /// Sends a Netlink message with the given slice of data. Returns the number of bytes sent if
+    /// successful.
+    pub fn send(&self, data: &[u8]) -> io::Result<usize> {
+        let len = data.len();
+        let ptr = data.as_ptr() as *const c_void;
+        debug!("Sending {} byte netlink message", len);
+        let result = cvt(unsafe { mnl_sys::mnl_socket_sendto(self.socket, ptr, len) })?;
+        Ok(result as usize)
+    }
+
+    /// Sends all messages in an iterator to the socket. Aborts as soon as an error is encountered.
+    /// Aborts and returns `Other` error if a send operation returned without sending the entire
+    /// message.
+    pub fn send_all<'a, I>(&self, iter: I) -> io::Result<()>
+    where
+        I: IntoIterator<Item = &'a [u8]>,
+    {
+        for data in iter {
+            if self.send(data)? < data.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "sendto did not send entire message",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Receives a Netlink message from the socket. Returns the number of bytes written to `buffer`
+    /// on success. If the message does not fit in the provided buffer an error will be returned
+    /// a partial message will be written to `buffer` and the rest discarded.
+    pub fn recv(&self, buffer: &mut [u8]) -> io::Result<usize> {
+        let len = buffer.len();
+        let ptr = buffer.as_mut_ptr() as *mut c_void;
+        let result = cvt(unsafe { mnl_sys::mnl_socket_recvfrom(self.socket, ptr, len) })?;
+        Ok(result as usize)
+    }
+
+    /// Obtain Netlink PortID from netlink socket.
+    pub fn portid(&self) -> libc::c_uint {
+        unsafe { mnl_sys::mnl_socket_get_portid(self.socket) }
+    }
+
+    /// Tries to close the socket, returns the corresponding error on failure.
+    pub fn close(self) -> io::Result<()> {
+        cvt(unsafe { mnl_sys::mnl_socket_close(self.socket) })?;
+        mem::forget(self);
+        Ok(())
+    }
+
+    /// Returns the pointer to the underlying C struct. Can be used with the `mnl_sys` crate to
+    /// perform actions not yet exposed in this safe abstraction.
+    pub fn as_raw_socket(&self) -> *mut mnl_sys::mnl_socket {
+        self.socket
+    }
+}
+
+impl Drop for Socket {
+    fn drop(&mut self) {
+        unsafe { mnl_sys::mnl_socket_close(self.socket) };
+    }
+}
+
+impl AsRawFd for Socket {
+    fn as_raw_fd(&self) -> RawFd {
+        unsafe { mnl_sys::mnl_socket_get_fd(self.socket) }
+    }
+}


### PR DESCRIPTION
This PR add's code to the `mnl` crate and the safe abstractions we will need to talk to the firewall. I think this is more or less everything we need to expose from `libmnl` to do everything we want. I might clean it up and improve it as the other code stabilizes, but I still think it's valuable to get what I have now reviewed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mnl-rs/2)
<!-- Reviewable:end -->
