### PR TITLE
Improve callback support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,14 @@ addons:
     packages:
     - libmnl-dev
 
-before_script:
-  - rustup component add rustfmt-preview
-  - rustfmt --version
-
 script:
   - cd mnl/
   - cargo build --verbose --no-default-features
   - cargo test --verbose --no-default-features
   - cd ../
   - if [ "${TRAVIS_RUST_VERSION}" = "nightly" ]; then
+      rustup component add rustfmt-preview;
+      rustfmt --version;
       cargo fmt -- --check --unstable-features;
     else
       echo "Not checking formatting on this build";

--- a/mnl-sys/Cargo.toml
+++ b/mnl-sys/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "mullvad/mnl-rs" }
 mnl-1-0-4 = []
 
 [dependencies]
-libc = "0.2.40"
+libc = "0.2.41"
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/mnl/src/callback.rs
+++ b/mnl/src/callback.rs
@@ -13,14 +13,64 @@ pub enum CbResult {
     Ok,
 }
 
+/// Callback function signature.
+/// TODO: Write abstraction for `nlmsghdr` that can reach all fields and payload.
+pub type Callback<T> = fn(msg: &libc::nlmsghdr, data: &mut T) -> libc::c_int;
+
+
 /// Callback runqueue for netlink messages. Checks that all netlink messages in `buffer` are OK.
 pub fn cb_run(buffer: &[u8], seq: u32, portid: u32) -> io::Result<CbResult> {
     let len = buffer.len();
     let buf = buffer.as_ptr() as *const libc::c_void;
-    debug!("Processing {} byte netlink message", len);
+    debug!("Processing {} byte netlink message without a callback", len);
     match unsafe { mnl_sys::mnl_cb_run(buf, len, seq, portid, None, ptr::null_mut()) } {
-        i if i <= -1 => Err(io::Error::last_os_error()),
+        i if i <= mnl_sys::MNL_CB_ERROR => Err(io::Error::last_os_error()),
         mnl_sys::MNL_CB_STOP => Ok(CbResult::Stop),
         _ => Ok(CbResult::Ok),
     }
+}
+
+/// Callback runqueue for netlink messages. Checks that all netlink messages in `buffer` are OK.
+/// Calls the given `callback` if needed.
+pub fn cb_run2<T>(
+    buffer: &[u8],
+    seq: u32,
+    portid: u32,
+    callback: Callback<T>,
+    data: &mut T,
+) -> io::Result<CbResult> {
+    let len = buffer.len();
+    let buf = buffer.as_ptr() as *const libc::c_void;
+    let mut callback_context = CallbackContext { callback, data };
+    debug!("Processing {} byte netlink message with callback", len);
+    match unsafe {
+        mnl_sys::mnl_cb_run(
+            buf,
+            len,
+            seq,
+            portid,
+            Some(callback_wrapper::<T>),
+            &mut callback_context as *mut _ as *mut libc::c_void,
+        )
+    } {
+        i if i <= mnl_sys::MNL_CB_ERROR => Err(io::Error::last_os_error()),
+        mnl_sys::MNL_CB_STOP => Ok(CbResult::Stop),
+        _ => Ok(CbResult::Ok),
+    }
+}
+
+
+/// Internal struct for helping to convert the unsafe FFI callback to the safe `Callback`.
+struct CallbackContext<'a, T: 'a> {
+    pub callback: Callback<T>,
+    pub data: &'a mut T,
+}
+
+/// Internal FFI callback converting the callback from libmnl into a `Callback<T>` callback.
+extern "C" fn callback_wrapper<T>(
+    nlh: *const libc::nlmsghdr,
+    data: *mut libc::c_void,
+) -> libc::c_int {
+    let context: &mut CallbackContext<T> = unsafe { &mut *(data as *mut CallbackContext<T>) };
+    (context.callback)(unsafe { &*nlh }, context.data)
 }


### PR DESCRIPTION
You have not reviewed this crate before. But a quite simple change and probably good if you have some insight into this repository.

So, adding support for running `cb_run` with a callback. Not sure if we'll need it, but it was easy to add so better do it I thought. Might make it easier to debug returned messages later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mnl-rs/4)
<!-- Reviewable:end -->
