### PR TITLE
Allow libdir as env var

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
   - cargo test --verbose --no-default-features
   - cd ../
   - if [ "${TRAVIS_RUST_VERSION}" = "nightly" ]; then
-      cargo fmt -- --write-mode=diff;
+      cargo fmt -- --check --unstable-features;
     else
       echo "Not checking formatting on this build";
     fi

--- a/mnl-sys/build.rs
+++ b/mnl-sys/build.rs
@@ -1,5 +1,8 @@
 extern crate pkg_config;
 
+use std::env;
+use std::path::PathBuf;
+
 #[cfg(feature = "mnl-1-0-4")]
 const MIN_VERSION: &str = "1.0.4";
 #[cfg(not(feature = "mnl-1-0-4"))]
@@ -8,11 +11,23 @@ const MIN_VERSION: &str = "1.0.3";
 
 #[cfg(target_os = "linux")]
 fn main() {
-    println!("Minimum libmnl version: {}", MIN_VERSION);
-    pkg_config::Config::new()
-        .atleast_version(MIN_VERSION)
-        .probe("libmnl")
-        .unwrap();
+    if let Ok(lib_dir) = env::var("LIBMNL_LIB_DIR").map(PathBuf::from) {
+        if !lib_dir.is_dir() {
+            panic!(
+                "libmnl library directory does not exist: {}",
+                lib_dir.display()
+            );
+        }
+        println!("cargo:rustc-link-search=native={}", lib_dir.display());
+        println!("cargo:rustc-link-lib=mnl");
+    } else {
+        // Trying with pkg-config instead
+        println!("Minimum libmnl version: {}", MIN_VERSION);
+        pkg_config::Config::new()
+            .atleast_version(MIN_VERSION)
+            .probe("libmnl")
+            .unwrap();
+    }
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/mnl/src/callback.rs
+++ b/mnl/src/callback.rs
@@ -1,4 +1,4 @@
-use mnl_sys::{self, c_int, c_void, nlmsghdr};
+use mnl_sys::{self, c_void};
 
 use std::io;
 use std::ptr;


### PR DESCRIPTION
Adding a way to control how the crate looks for the `libmnl` artifact to link to. If `LIBMNL_LIB_DIR` is set it will use that, if not, it will use `pkg-config` just as before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mnl-rs/5)
<!-- Reviewable:end -->
