### PR TITLE
Make cargo rerun if lib dir changes

### DIFF
--- a/mnl-sys/build.rs
+++ b/mnl-sys/build.rs
@@ -11,7 +11,8 @@ const MIN_VERSION: &str = "1.0.3";
 
 #[cfg(target_os = "linux")]
 fn main() {
-    if let Ok(lib_dir) = env::var("LIBMNL_LIB_DIR").map(PathBuf::from) {
+    println!("cargo:rerun-if-env-changed=LIBMNL_LIB_DIR");
+    if let Some(lib_dir) = env::var_os("LIBMNL_LIB_DIR").map(PathBuf::from) {
         if !lib_dir.is_dir() {
             panic!(
                 "libmnl library directory does not exist: {}",


### PR DESCRIPTION
I learned this trick from `openssl-sys` (https://github.com/sfackler/rust-openssl/blob/master/openssl-sys/build/main.rs#L48) that makes cargo detect environment variable changes and trigger reruns.

Problem without this is that if you have a build and changes `LIBMNL_LIB_DIR` and run `cargo build` again then `mnl-sys` will not be re-built. Forcing a complete `cargo clean` which will make the build take much longer. This is a nicer way to make it work cleanly.

Also realized I can use `var_os` instead of `var` to not force the path in the variable to be valid UTF-8.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mnl-rs/6)
<!-- Reviewable:end -->
