### PR TITLE
Use libc re-exports from mnl-sys

### DIFF
--- a/mnl-sys/src/bindings.rs
+++ b/mnl-sys/src/bindings.rs
@@ -1,5 +1,5 @@
 use core::option::Option;
-pub use libc::{c_char, c_int, c_uint, c_void, nlattr, nlmsghdr, pid_t, socklen_t, FILE};
+use libc::{c_char, c_int, c_uint, c_void, nlattr, nlmsghdr, pid_t, socklen_t, FILE};
 
 pub const MNL_SOCKET_AUTOPID: c_int = 0;
 pub const MNL_ALIGNTO: c_int = 4;

--- a/mnl-sys/src/lib.rs
+++ b/mnl-sys/src/lib.rs
@@ -18,7 +18,7 @@
 #![no_std]
 #![cfg(target_os = "linux")]
 
-extern crate libc;
+pub extern crate libc;
 
 #[allow(non_snake_case)]
 pub fn MNL_SOCKET_BUFFER_SIZE() -> libc::c_long {

--- a/mnl/src/callback.rs
+++ b/mnl/src/callback.rs
@@ -1,4 +1,4 @@
-use mnl_sys::{self, c_void};
+use mnl_sys::{self, libc};
 
 use std::io;
 use std::ptr;
@@ -16,7 +16,7 @@ pub enum CbResult {
 /// Callback runqueue for netlink messages. Checks that all netlink messages in `buffer` are OK.
 pub fn cb_run(buffer: &[u8], seq: u32, portid: u32) -> io::Result<CbResult> {
     let len = buffer.len();
-    let buf = buffer.as_ptr() as *const c_void;
+    let buf = buffer.as_ptr() as *const libc::c_void;
     debug!("Processing {} byte netlink message", len);
     match unsafe { mnl_sys::mnl_cb_run(buf, len, seq, portid, None, ptr::null_mut()) } {
         i if i <= -1 => Err(io::Error::last_os_error()),

--- a/mnl/src/socket.rs
+++ b/mnl/src/socket.rs
@@ -1,5 +1,8 @@
 use libc;
-use mnl_sys::{self, c_uint, c_void};
+use mnl_sys::{
+    self,
+    libc::{c_uint, c_void, pid_t},
+};
 
 use std::io;
 use std::mem;
@@ -101,7 +104,7 @@ impl Socket {
     }
 
     /// Bind the Netlink socket.
-    pub fn bind(&self, groups: c_uint, pid: libc::pid_t) -> io::Result<()> {
+    pub fn bind(&self, groups: c_uint, pid: pid_t) -> io::Result<()> {
         cvt(unsafe { mnl_sys::mnl_socket_bind(self.socket, groups, pid) })?;
         Ok(())
     }
@@ -145,7 +148,7 @@ impl Socket {
     }
 
     /// Obtain Netlink PortID from netlink socket.
-    pub fn portid(&self) -> libc::c_uint {
+    pub fn portid(&self) -> c_uint {
         unsafe { mnl_sys::mnl_socket_get_portid(self.socket) }
     }
 


### PR DESCRIPTION
If someone depend on `mnl` I don't want them to have to depend on `libc` or `mnl-sys`, that should be abstracted away. As such I now use the types re-exported in `mnl-sys`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mnl-rs/7)
<!-- Reviewable:end -->
