### PR TITLE
Upgrade to Rust 2018 edition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+### Categories each change fall into
+
+* **Added**: for new features.
+* **Changed**: for changes in existing functionality.
+* **Deprecated**: for soon-to-be removed features.
+* **Removed**: for now removed features.
+* **Fixed**: for any bug fixes.
+* **Security**: in case of vulnerabilities.
+
+
+## [Unreleased]
+### Added
+- Add `cb_run2` with support for callback closures.
+
+### Changed
+- Upgraded crates to Rust 2018 edition.
+
+
+## [0.1.0] - 2018-08-29
+### Added
+- Bindings to `libmnl 1.0.4`
+- Initial safe abstraction. Just basic socket support.

--- a/mnl-sys/Cargo.toml
+++ b/mnl-sys/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/mullvad/mnl-rs"
 readme = "README.md"
 keywords = ["netlink", "libmnl"]
 categories = ["network-programming", "os::unix-apis", "external-ffi-bindings", "no-std"]
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "mullvad/mnl-rs" }

--- a/mnl-sys/src/lib.rs
+++ b/mnl-sys/src/lib.rs
@@ -40,7 +40,7 @@
 #![no_std]
 #![cfg(target_os = "linux")]
 
-pub extern crate libc;
+pub use libc;
 
 #[allow(non_snake_case)]
 pub fn MNL_SOCKET_BUFFER_SIZE() -> libc::c_long {
@@ -56,4 +56,4 @@ pub fn MNL_ALIGN(len: i32) -> i32 {
 
 #[allow(non_camel_case_types)]
 mod bindings;
-pub use bindings::*;
+pub use crate::bindings::*;

--- a/mnl/Cargo.toml
+++ b/mnl/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/mullvad/mnl-rs"
 readme = "../README.md"
 keywords = ["netlink", "libmnl"]
 categories = ["network-programming", "os::unix-apis", "api-bindings"]
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "mullvad/mnl-rs" }

--- a/mnl/src/callback.rs
+++ b/mnl/src/callback.rs
@@ -1,7 +1,7 @@
 use mnl_sys::{self, libc};
 
-use std::io;
-use std::ptr;
+use log::debug;
+use std::{io, ptr};
 
 
 /// The result of processing a batch of netlink responses.
@@ -61,7 +61,7 @@ pub fn cb_run2<T>(
 
 
 /// Internal struct for helping to convert the unsafe FFI callback to the safe `Callback`.
-struct CallbackContext<'a, T: 'a> {
+struct CallbackContext<'a, T> {
     pub callback: Callback<T>,
     pub data: &'a mut T,
 }
@@ -71,6 +71,7 @@ extern "C" fn callback_wrapper<T>(
     nlh: *const libc::nlmsghdr,
     data: *mut libc::c_void,
 ) -> libc::c_int {
-    let context: &mut CallbackContext<T> = unsafe { &mut *(data as *mut CallbackContext<T>) };
+    let context: &mut CallbackContext<'_, T> =
+        unsafe { &mut *(data as *mut CallbackContext<'_, T>) };
     (context.callback)(unsafe { &*nlh }, context.data)
 }

--- a/mnl/src/lib.rs
+++ b/mnl/src/lib.rs
@@ -40,17 +40,14 @@
 #![cfg(target_os = "linux")]
 #![deny(missing_docs)]
 
-extern crate libc;
-#[macro_use]
-extern crate log;
-pub extern crate mnl_sys;
+pub use mnl_sys;
 
 /// Module for helper functions checking FFI return values for error codes.
 /// "cvt" stands for "check value T", where T is the return value
 mod cvt;
 
 mod callback;
-pub use callback::*;
+pub use crate::callback::*;
 
 mod socket;
-pub use socket::*;
+pub use crate::socket::*;

--- a/mnl/src/socket.rs
+++ b/mnl/src/socket.rs
@@ -1,14 +1,15 @@
 use libc;
+use log::debug;
 use mnl_sys::{
     self,
     libc::{c_uint, c_void, pid_t},
 };
+use std::{
+    io, mem,
+    os::unix::io::{AsRawFd, RawFd},
+};
 
-use std::io;
-use std::mem;
-use std::os::unix::io::{AsRawFd, RawFd};
-
-use cvt::cvt;
+use crate::cvt::cvt;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 #[allow(missing_docs)]
@@ -41,7 +42,7 @@ impl Bus {
     /// Converts the given integer to a netlink bus variant. Returns `None` if the value does
     /// not match any bus.
     pub fn try_from(bus: i32) -> Option<Self> {
-        use Bus::*;
+        use crate::Bus::*;
         let variant = match bus {
             libc::NETLINK_ROUTE => Route,
             libc::NETLINK_UNUSED => Unused,


### PR DESCRIPTION
Just upgrading to Rust 2018. Not that we really need it, but it was a low hanging fruit that I wanted to pick before we ran into trouble.

Since we have a release it's also a good time to start maintaining a changelog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mnl-rs/9)
<!-- Reviewable:end -->
