### PR TITLE
Prepare release 0.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rust:
   - nightly
   - stable
   - beta
+  - 1.31.0
 os:
   - linux
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+
+
+## [0.2.0] - 2019-09-XX <- UPDATE BEFORE MERGING
 ### Added
 - Add `cb_run2` with support for callback closures.
 

--- a/mnl-sys/Cargo.toml
+++ b/mnl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mnl-sys"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Mullvad VPN <admin@mullvad.net>", "Linus Färnstrand <faern@faern.net>"]
 license = "MIT/Apache-2.0"
 description = "Low level FFI bindings to libmnl. A minimalistic user-space library oriented to Netlink developers"

--- a/mnl/Cargo.toml
+++ b/mnl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mnl"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Mullvad VPN <admin@mullvad.net>", "Linus Färnstrand <faern@faern.net>"]
 license = "MIT/Apache-2.0"
 description = "Safe abstraction for libmnl, a minimalistic user-space library oriented to Netlink developers"
@@ -19,4 +19,4 @@ mnl-1-0-4 = ["mnl-sys/mnl-1-0-4"]
 [dependencies]
 libc = "0.2.40"
 log = "0.4"
-mnl-sys = { path = "../mnl-sys", version = "0.1" }
+mnl-sys = { path = "../mnl-sys", version = "0.2" }


### PR DESCRIPTION
In an effort to reduce our dependencies on crates directly from git I want to release this. There are some changes we want that just sit around in the master branch, but that we never get around to actually release.

Making it a breaking change since we upgrade to Rust 2018 and the minimum supported Rust version is increased.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mnl-rs/10)
<!-- Reviewable:end -->
