### PR TITLE
Update libc dependency to 0.2.107

### DIFF
--- a/mnl-sys/Cargo.toml
+++ b/mnl-sys/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "mullvad/mnl-rs" }
 mnl-1-0-4 = []
 
 [dependencies]
-libc = "0.2.41"
+libc = "0.2.107"
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/mnl/Cargo.toml
+++ b/mnl/Cargo.toml
@@ -17,6 +17,6 @@ travis-ci = { repository = "mullvad/mnl-rs" }
 mnl-1-0-4 = ["mnl-sys/mnl-1-0-4"]
 
 [dependencies]
-libc = "0.2.40"
+libc = "0.2.107"
 log = "0.4"
 mnl-sys = { path = "../mnl-sys", version = "0.2" }


### PR DESCRIPTION
This PR updates the `libc` crate dependency to the most recent released version.

Compared to the version that was used previously (0.2.40 and 0.2.41), the new version contains the changes made in rust-lang/libc#2152 (and released in libc version 0.2.95), which allows `mnl-rs` to be used on Linux systems running musl-libc instead of glibc.

This PR is related to mullvad/nftnl-rs#48. In order to be able to use nftnl-rs on musl-libc systems, the version number of mnl-rs should probably be bumped after merging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mnl-rs/11)
<!-- Reviewable:end -->
