### PR TITLE
Fix minimal versions (cargo +nightly update -Z minimal-versions)

### DIFF
--- a/mnl-sys/Cargo.toml
+++ b/mnl-sys/Cargo.toml
@@ -20,4 +20,4 @@ mnl-1-0-4 = []
 libc = "0.2.41"
 
 [build-dependencies]
-pkg-config = "0.3"
+pkg-config = "0.3.16"

--- a/mnl/Cargo.toml
+++ b/mnl/Cargo.toml
@@ -18,5 +18,5 @@ mnl-1-0-4 = ["mnl-sys/mnl-1-0-4"]
 
 [dependencies]
 libc = "0.2.40"
-log = "0.4"
+log = "0.4.4"
 mnl-sys = { path = "../mnl-sys", version = "0.2" }

--- a/mnl/src/callback.rs
+++ b/mnl/src/callback.rs
@@ -1,6 +1,5 @@
 use mnl_sys::{self, libc};
 
-use log::debug;
 use std::{io, ptr};
 
 
@@ -22,7 +21,7 @@ pub type Callback<T> = fn(msg: &libc::nlmsghdr, data: &mut T) -> libc::c_int;
 pub fn cb_run(buffer: &[u8], seq: u32, portid: u32) -> io::Result<CbResult> {
     let len = buffer.len();
     let buf = buffer.as_ptr() as *const libc::c_void;
-    debug!("Processing {} byte netlink message without a callback", len);
+    log::debug!("Processing {} byte netlink message without a callback", len);
     match unsafe { mnl_sys::mnl_cb_run(buf, len, seq, portid, None, ptr::null_mut()) } {
         i if i <= mnl_sys::MNL_CB_ERROR => Err(io::Error::last_os_error()),
         mnl_sys::MNL_CB_STOP => Ok(CbResult::Stop),
@@ -42,7 +41,7 @@ pub fn cb_run2<T>(
     let len = buffer.len();
     let buf = buffer.as_ptr() as *const libc::c_void;
     let mut callback_context = CallbackContext { callback, data };
-    debug!("Processing {} byte netlink message with callback", len);
+    log::debug!("Processing {} byte netlink message with callback", len);
     match unsafe {
         mnl_sys::mnl_cb_run(
             buf,

--- a/mnl/src/socket.rs
+++ b/mnl/src/socket.rs
@@ -1,5 +1,4 @@
 use libc;
-use log::debug;
 use mnl_sys::{
     self,
     libc::{c_uint, c_void, pid_t},
@@ -115,7 +114,7 @@ impl Socket {
     pub fn send(&self, data: &[u8]) -> io::Result<usize> {
         let len = data.len();
         let ptr = data.as_ptr() as *const c_void;
-        debug!("Sending {} byte netlink message", len);
+        log::debug!("Sending {} byte netlink message", len);
         let result = cvt(unsafe { mnl_sys::mnl_socket_sendto(self.socket, ptr, len) })?;
         Ok(result as usize)
     }


### PR DESCRIPTION
When issuing `cargo +nightly update -Z minimal-versions && cargo build` on this crate it gives errors. This is because some dependency versions were too loosely defined and allowed crates so old that they don't build on current Rust/Rust 2018.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mnl-rs/12)
<!-- Reviewable:end -->
