### PR TITLE
Forcing mnl to use mnl-sys 0.2.1 at least

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+
+## [0.2.2] - 2022-02-11
+### Fixed
+- Just releasing `mnl` with correct minimal dependency specification
+  on `mnl-sys` (0.2.1).
+
+
 ## [0.2.1] - 2022-02-11
 ### Fixed
 - Specify dependency versions more exactly to allow building with minimal versions

--- a/mnl/Cargo.toml
+++ b/mnl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mnl"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Mullvad VPN <admin@mullvad.net>", "Linus Färnstrand <faern@faern.net>"]
 license = "MIT/Apache-2.0"
 description = "Safe abstraction for libmnl, a minimalistic user-space library oriented to Netlink developers"
@@ -19,4 +19,4 @@ mnl-1-0-4 = ["mnl-sys/mnl-1-0-4"]
 [dependencies]
 libc = "0.2.40"
 log = "0.4.4"
-mnl-sys = { path = "../mnl-sys", version = "0.2" }
+mnl-sys = { path = "../mnl-sys", version = "0.2.1" }


### PR DESCRIPTION
A small miss in the last publishing.
Without this the minimal-versions stuff is very moot, it does nothing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mnl-rs/13)
<!-- Reviewable:end -->
