### PR TITLE
Add `links` manifest key to `mnl-sys`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Added
+- Specify `links` manifest key `mnl-sys`. This allows dependants to pass custom build flags.
+
 
 ## [0.2.2] - 2022-02-11
 ### Fixed

--- a/mnl-sys/Cargo.toml
+++ b/mnl-sys/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = ["netlink", "libmnl"]
 categories = ["network-programming", "os::unix-apis", "external-ffi-bindings", "no-std"]
 edition = "2018"
+links = "mnl"
 
 [badges]
 travis-ci = { repository = "mullvad/mnl-rs" }

--- a/mnl-sys/README.md
+++ b/mnl-sys/README.md
@@ -8,9 +8,20 @@ repository.
 
 ## Linking to libmnl
 
-By default this crate uses pkg-config to find and link to [`libmnl`]. To manually configure
-where to look for the library, set the environment variable `LIBMNL_LIB_DIR` to point to the
-directory where `libmnl.so` or `libmnl.a` resides.
+### `pkg-config`
+By default this crate uses pkg-config to find and link [`libmnl`].
+
+### Manually
+To manually configure where to look for the library, set the environment variable `LIBMNL_LIB_DIR`
+to point to the directory where `libmnl.so` or `libmnl.a` resides, or [`override the build script`]
+to manually set the linker directives for `mnl`:
+
+```toml
+# .cargo/config.toml
+[target.x86_64-unknown-linux-gnu.mnl]
+rustc-link-lib = ["mnl"]
+rustc-link-search = ["<type>=<path-to-libmnl>"]
+```
 
 ## Selecting version of `libmnl`
 
@@ -30,5 +41,6 @@ mnl-sys = { version = "0.1", features = ["mnl-1-0-4"] }
 [`libmnl`]: https://netfilter.org/projects/libmnl/
 [`mnl`]: https://crates.io/crates/mnl
 [`bindgen`]: https://crates.io/crates/bindgen
+[`override the build script`]: https://doc.rust-lang.org/cargo/reference/build-scripts.html#overriding-build-scripts
 
 License: MIT/Apache-2.0


### PR DESCRIPTION
This PR adds the [links manifest key](https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key) to `mnl-sys`, effectively allowing users to bypass mnl-sys/build.rs, setting their own compiler flags and [passing the required metadata ahead-of-time](https://doc.rust-lang.org/cargo/reference/build-scripts.html#overriding-build-scripts). Cargo will also know statically that mnl-sys links against libmnl. I don't know what that information is used for however, other than documentation ¯\\_(ツ)_/¯

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mnl-rs/16)
<!-- Reviewable:end -->
