### PR TITLE
Add `cargo-semver-checks` to CI

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -1,0 +1,11 @@
+---
+name: "Install libmnl"
+description: "Set up build environment with libmnl"
+runs:
+  using: "composite"
+  steps:
+    - name: Install build dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libmnl-dev

--- a/.github/workflows/check-semver.yml
+++ b/.github/workflows/check-semver.yml
@@ -1,0 +1,31 @@
+---
+name: Check SemVer compatibility
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+env:
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+  CARGO_TERM_VERBOSE: 'true'
+  # The below settings are based on advice from:
+  # https://corrode.dev/blog/tips-for-faster-ci-builds/
+  CARGO_INCREMENTAL: 0
+  CARGO_PROFILE_TEST_DEBUG: 0
+
+jobs:
+  check-semver:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install libmnl
+        uses: ./.github/actions/install-deps
+      - name: mnl
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          manifest-path: mnl/Cargo.toml
+      - name: mnl-sys
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          manifest-path: mnl-sys/Cargo.toml


### PR DESCRIPTION
This PR adds a safe guard against accidentally publishing a new SemVer breaking version of `mnl` or `mnl-sys`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mnl-rs/18)
<!-- Reviewable:end -->
