### PR TITLE
Fix RUSTSEC-2025-0142 (unsoundness in `cb_run`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+### Fixed
+- Fix unsoundness in `cb_run` and `cb_run2` when called with malformed netlink messages.
+  This fixes RUSTSEC-2025-0142.
 
 
 ## [0.3.0] - 2025-11-17

--- a/mnl/src/callback.rs
+++ b/mnl/src/callback.rs
@@ -1,3 +1,4 @@
+use crate::NlMessages;
 use mnl_sys::{self, libc};
 
 use std::{io, ptr};
@@ -16,9 +17,14 @@ pub enum CbResult {
 pub type Callback<T> = fn(msg: &libc::nlmsghdr, data: &mut T) -> libc::c_int;
 
 /// Callback runqueue for netlink messages. Checks that all netlink messages in `buffer` are OK.
+/// `buffer` must be aligned to `size_of::<nlmsghdr>()`, or this fails.
 pub fn cb_run(buffer: &[u8], seq: u32, portid: u32) -> io::Result<CbResult> {
+    // NOTE: See comment on [`validate_messages`] for why we need to validate messages here.
+    validate_messages(buffer)?;
+
     let len = buffer.len();
     let buf = buffer.as_ptr() as *const libc::c_void;
+
     log::debug!("Processing {} byte netlink message without a callback", len);
     match unsafe { mnl_sys::mnl_cb_run(buf, len, seq, portid, None, ptr::null_mut()) } {
         i if i <= mnl_sys::MNL_CB_ERROR => Err(io::Error::last_os_error()),
@@ -29,6 +35,7 @@ pub fn cb_run(buffer: &[u8], seq: u32, portid: u32) -> io::Result<CbResult> {
 
 /// Callback runqueue for netlink messages. Checks that all netlink messages in `buffer` are OK.
 /// Calls the given `callback` if needed.
+/// `buffer` must be aligned to `size_of::<nlmsghdr>()`, or this fails.
 pub fn cb_run2<T>(
     buffer: &[u8],
     seq: u32,
@@ -36,6 +43,9 @@ pub fn cb_run2<T>(
     callback: Callback<T>,
     data: &mut T,
 ) -> io::Result<CbResult> {
+    // NOTE: See comment on [`validate_messages`] for why we need to validate messages here.
+    validate_messages(buffer)?;
+
     let len = buffer.len();
     let buf = buffer.as_ptr() as *const libc::c_void;
     let mut callback_context = CallbackContext { callback, data };
@@ -54,6 +64,27 @@ pub fn cb_run2<T>(
         mnl_sys::MNL_CB_STOP => Ok(CbResult::Stop),
         _ => Ok(CbResult::Ok),
     }
+}
+
+/// libmnl contains a bug in `mnl_nlmsg_ok` where it casts `nlh->nlmsg_len` to an `int`,
+/// i.e. `(int)nlh->nlmsg_len`. This becomes negative if `nlmsg_len` is greater than `INT_MAX`,
+/// causing the validation to succeed even if the buffer is too small. `mnl_nlmsg_ok` is
+/// used by `mnl_cb_run` and `mnl_cb_run2`.
+///
+/// This was fixed on 2023-11-04 in commit `754c9de5ea1bea821495523cf01989299552e524`,
+/// but the latest version of libmnl 1.0.5 was released on 2022-04-05, so as of writing
+/// there is no released version of libmnl that contains the fix.
+///
+/// Thus we need our own validation.
+///
+/// See the libmnl git repo and that commit for details: git://git.netfilter.org/libmnl
+///
+/// This addresses [RUSTSEC-2025-0142](https://rustsec.org/advisories/RUSTSEC-2025-0142.html).
+fn validate_messages(buffer: &[u8]) -> io::Result<()> {
+    NlMessages::new(buffer).try_for_each(|msg| {
+        msg?;
+        Ok(())
+    })
 }
 
 /// Internal struct for helping to convert the unsafe FFI callback to the safe `Callback`.

--- a/mnl/src/messages.rs
+++ b/mnl/src/messages.rs
@@ -36,7 +36,7 @@ impl<'a> Iterator for NlMessages<'a> {
         }
 
         // Safety:
-        // nlmsghdr is a C struct, valid for all bit-patters, and we've checked alignment and length
+        // nlmsghdr is a C struct, valid for all bit-patterns, and we've checked alignment and length
         let header = unsafe { header.read() };
 
         let msg_len = header.nlmsg_len as usize;


### PR DESCRIPTION
libmnl contains a bug in `mnl_nlmsg_ok` where it casts `nlh->nlmsg_len` to an `int`, i.e. `(int)nlh->nlmsg_len`. This becomes negative if `nlmsg_len` is greater than `INT_MAX`, causing the validation to succeed even if the buffer is too small. `mnl_nlmsg_ok` is used by `mnl_cb_run` and `mnl_cb_run2`.

This was fixed in commit [`754c9de5ea1bea821495523cf01989299552e524`](https://git.netfilter.org/libmnl/commit/?id=754c9de5ea1bea821495523cf01989299552e524), but the latest version of libmnl 1.0.5 was released on 2022-04-05, so as of writing there is no released version of libmnl that contains the fix. Thus we need our own validation.

Closes #15.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mnl-rs/21)
<!-- Reviewable:end -->
