### PR TITLE
Release mnl 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [Unreleased]
+
+
+## [0.3.1] - 2026-02-10
 ### Fixed
 - Fix unsoundness in `cb_run` and `cb_run2` when called with malformed netlink messages.
   This fixes RUSTSEC-2025-0142.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "mnl"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "libc",
  "log",

--- a/mnl/Cargo.toml
+++ b/mnl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mnl"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Mullvad VPN <admin@mullvad.net>", "Linus Färnstrand <faern@faern.net>"]
 license = "MIT/Apache-2.0"
 description = "Safe abstraction for libmnl, a minimalistic user-space library oriented to Netlink developers"


### PR DESCRIPTION
## Fixed
* Fix unsoundness in cb_run and cb_run2 when called with malformed netlink messages. This fixes [RUSTSEC-2025-0142](https://rustsec.org/advisories/RUSTSEC-2025-0142.html).

https://github.com/mullvad/mnl-rs/compare/v0.3.0...d8d5234ffbfee2323f21ff2bebb3cc78c074078d

Closes https://github.com/mullvad/mnl-rs/issues/15.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mullvad/mnl-rs/23)
<!-- Reviewable:end -->
